### PR TITLE
Drop string support for target_size and preprocess_args

### DIFF
--- a/keras_model_specs/model_spec.py
+++ b/keras_model_specs/model_spec.py
@@ -3,7 +3,6 @@ import json
 import numpy as np
 import importlib
 
-from six import string_types
 from keras.preprocessing.image import load_img
 
 

--- a/keras_model_specs/model_spec.py
+++ b/keras_model_specs/model_spec.py
@@ -61,16 +61,6 @@ class ModelSpec(object):
         if isinstance(self.klass, str):
             self.klass = self._get_module_class(self.klass)
 
-        if isinstance(self.target_size, string_types):
-            self.target_size = self.target_size.split(',')
-        if self.target_size:
-            self.target_size = [int(v) for v in self.target_size]
-
-        if isinstance(self.preprocess_args, str):
-            self.preprocess_args = self.preprocess_args.split(',')
-        if self.preprocess_args:
-            self.preprocess_args = [int(v) for v in self.preprocess_args]
-
     def load_image(self, image_path):
         preprocess_input = PREPROCESS_FUNCTIONS[self.preprocess_func]
         img = load_img(image_path, target_size=self.target_size[:2])

--- a/keras_model_specs/model_specs.json
+++ b/keras_model_specs/model_specs.json
@@ -2,31 +2,31 @@
   "inception_v3": {
     "klass": "keras.applications.inception_v3.InceptionV3",
     "preprocess_func": "between_plus_minus_1",
-    "target_size": "224,224,3"
+    "target_size": [224, 224, 3]
   },
   "mobilenet_v1": {
     "klass": "keras.applications.mobilenet.MobileNet",
     "preprocess_func": "between_plus_minus_1",
-    "target_size": "224,224,3"
+    "target_size": [224, 224, 3]
   },
   "resnet50": {
     "klass": "keras.applications.resnet50.ResNet50",
     "preprocess_func": "mean_subtraction",
-    "target_size": "224,224,3"
+    "target_size": [224, 224, 3]
   },
   "vgg16": {
     "klass": "keras.applications.vgg16.VGG16",
     "preprocess_func": "mean_subtraction",
-    "target_size": "224,224,3"
+    "target_size": [224, 224, 3]
   },
   "vgg19": {
     "klass": "keras.applications.vgg19.VGG19",
     "preprocess_func": "mean_subtraction",
-    "target_size": "224,224,3"
+    "target_size": [224, 224, 3]
   },
   "xception": {
     "klass": "keras.applications.xception.Xception",
     "preprocess_func": "between_plus_minus_1",
-    "target_size": "299,299,3"
+    "target_size": [299, 299, 3]
   }
 }

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='keras-model-specs',
-    version='0.0.4',
+    version='0.0.5',
     description='A helper package for managing Keras model base architectures with overrides for target size and preprocessing functions.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',

--- a/tests/test_model_spec.py
+++ b/tests/test_model_spec.py
@@ -21,9 +21,9 @@ def test_returns_nonexistent_with_overrides():
     spec = ModelSpec.get(
         'nonexistent_v1',
         klass='keras.applications.mobilenet.MobileNet',
-        target_size='224,224,3',
+        target_size=[224, 224, 3],
         preprocess_func='mean_subtraction',
-        preprocess_args='1,2,3'
+        preprocess_args=[1, 2, 3]
     )
     assert spec is not None
     assert spec.klass == MobileNet
@@ -36,9 +36,9 @@ def test_returns_existing_with_overrides():
     spec = ModelSpec.get(
         'mobilenet_v1',
         klass='keras.applications.mobilenet.MobileNet',
-        target_size='512,512,3',
+        target_size=[512, 512, 3],
         preprocess_func='mean_subtraction',
-        preprocess_args='1,2,3'
+        preprocess_args=[1, 2, 3]
     )
     assert spec is not None
     assert spec.klass == MobileNet


### PR DESCRIPTION
Since these specs are JSON, there's no need for string parsing here.

Also, forcing `preprocess_args` to be an int array is a bug (dataset means are floats).