### PR TITLE
Load weights when no_top, pooling corrected

### DIFF
--- a/keras_model_specs/models/inception_v4.py
+++ b/keras_model_specs/models/inception_v4.py
@@ -23,7 +23,7 @@ import numpy as np
 import warnings
 # Keras Core
 from keras.layers.convolutional import MaxPooling2D, Convolution2D
-from keras.layers.pooling import AveragePooling2D
+from keras.layers.pooling import AveragePooling2D, GlobalAveragePooling2D, GlobalMaxPooling2D
 from keras.layers import Input, Dropout, Dense, Flatten, Activation
 from keras.layers.normalization import BatchNormalization
 from keras.layers.merge import concatenate
@@ -246,6 +246,7 @@ def InceptionV4(
         include_top=True,
         weights='imagenet',
         classes=1001,
+        pooling='avg',
         input_shape=(299, 299, 3),
         dropout_keep_prob=0.2):
     '''
@@ -256,6 +257,7 @@ def InceptionV4(
         weights: 'imagenet' or None
         include_top: whether to include the top layers
         input_shape: input shape
+        pooling: type of pooling in the end (if no top layers is selected)
 
     Returns:
         logits: the logits outputs of the model.
@@ -299,11 +301,20 @@ def InceptionV4(
                 WEIGHTS_PATH,
                 cache_subdir='models',
                 md5_hash='9fe79d77f793fe874470d84ca6ba4a3b')
+            model.load_weights(weights_path)
         else:
             weights_path = get_file(
                 'inception-v4_weights_tf_dim_ordering_tf_kernels_notop.h5',
                 WEIGHTS_PATH_NO_TOP,
                 cache_subdir='models',
                 md5_hash='9296b46b5971573064d12e4669110969')
-        model.load_weights(weights_path)
+            model.load_weights(weights_path)
+
+            if pooling == 'max':
+                pool = GlobalMaxPooling2D()(model.output)
+            else:
+                pool = GlobalAveragePooling2D()(model.output)
+
+            model = Model(model.input, pool)
+
     return model

--- a/keras_model_specs/models/resnet152.py
+++ b/keras_model_specs/models/resnet152.py
@@ -126,11 +126,17 @@ def ResNet152(
         weights='imagenet',
         classes=1000,
         input_shape=(224, 224, 3)):
-    '''Instantiate the ResNet152 architecture,
-    # Arguments
-        weights_path: path to pretrained weight file
-    # Returns
-        A Keras model instance.
+    '''
+    Instantiate ResNet152 Architecture
+    Args:
+        include_top: Include classifier layer
+        pooling: Type of pooling to include
+        weights: If use pre-trained weights on imagenet
+        classes: Number of outputs in the classifier layer
+        input_shape: Input shape of images
+
+    Returns: ResNet152 model
+
     '''
     eps = 1.1e-5
 

--- a/keras_model_specs/models/resnet152.py
+++ b/keras_model_specs/models/resnet152.py
@@ -188,21 +188,20 @@ def ResNet152(
 
         weights_path = get_file('resnet152_weights_tf.h5', WEIGHTS_PATH, cache_subdir='models',
                                 md5_hash='1d341ac3e61cd7f5338a90db32535ca2')
-        if include_top:
-            model.load_weights(weights_path)
 
+        model.load_weights(weights_path)
+
+    if not include_top:
+        model.layers.pop()
+        model.layers.pop()
+        model.layers.pop()
+        model.layers[-1].outbound_nodes = []
+
+        if pooling == 'max':
+            pool = GlobalMaxPooling2D()(model.output)
         else:
-            model.load_weights(weights_path)
-            model.layers.pop()
-            model.layers.pop()
-            model.layers.pop()
-            model.layers[-1].outbound_nodes = []
+            pool = GlobalAveragePooling2D()(model.output)
 
-            if pooling == 'max':
-                pool = GlobalMaxPooling2D()(model.output)
-            else:
-                pool = GlobalAveragePooling2D()(model.output)
-
-            model = Model(model.input, pool)
+        model = Model(model.input, pool)
 
     return model

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='keras-model-specs',
-    version='0.0.9',
+    version='0.0.10',
     description='A helper package for managing Keras model base architectures with overrides for target size and preprocessing functions.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',


### PR DESCRIPTION
As it was before, when `include_top` was false we weren't loading imagenet weights. I think that in 100% of our cases we will want to fine-tune and remove the last layers so I think that this modification makes sense. 

Also there was an error by putting the pooling layers after flatten layer and before the Dense layer before loading weights.