### PR TITLE
Add inception_resnet_v2

### DIFF
--- a/keras_model_specs/model_specs.json
+++ b/keras_model_specs/model_specs.json
@@ -1,4 +1,9 @@
 {
+  "inception_resnet_v2": {
+    "klass": "keras.applications.inception_resnet_v2.InceptionResNetV2",
+    "preprocess_func": "between_plus_minus_1",
+    "target_size": [299, 299, 3]
+  },
   "inception_v3": {
     "klass": "keras.applications.inception_v3.InceptionV3",
     "preprocess_func": "between_plus_minus_1",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='keras-model-specs',
-    version='0.0.11',
+    version='0.0.12',
     description='A helper package for managing Keras model base architectures with overrides for target size and preprocessing functions.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',

--- a/tests/test_model_spec.py
+++ b/tests/test_model_spec.py
@@ -8,6 +8,7 @@ from keras_model_specs import ModelSpec
 
 
 EXPECTED_BASE_SPECS = [
+    'inception_resnet_v2',
     'inception_v3',
     'inception_v4',
     'mobilenet_v1',
@@ -77,6 +78,10 @@ def test_load_image_for_all_base_specs():
         spec = ModelSpec.get(name, preprocess_args=[1, 2, 3])
         image_data = spec.load_image('tests/files/cat.jpg')
         assert image_data.any()
+
+
+def test_model_inception_v3():
+    assert_model_predict('inception_resnet_v2', 1000)
 
 
 def test_model_inception_v3():


### PR DESCRIPTION
- Add model `inception_resnet_v2` as now is it supported by the newest version of Keras (2.0.9) 
- Add test case for `inception_resnet_v2`