### PR TITLE
Freeze at Keras 2.1.4 until compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='keras-model-specs',
-    version='0.0.16',
+    version='0.0.17',
     description='A helper package for managing Keras model base architectures with overrides for target size and preprocessing functions.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',
@@ -13,7 +13,7 @@ setup(
     packages=find_packages(exclude=['tests', '.cache', '.venv', '.git', 'dist']),
     include_package_data=True,
     install_requires=[
-        'Keras>=2.1.3',
+        'Keras==2.1.4',
         'h5py',
         'Pillow',
         'six'


### PR DESCRIPTION
We started seeing downstream failures in CI of packages that depend on this (keras-trainer and downstream from it) since the release of Keras 2.1.5 yesterday — it looks like this:

```
WARNING:tensorflow:Variable *= will be deprecated. Use variable.assign_mul if you want assignment to the variable value or 'x = x * y' if you want a new python Tensor object.
Traceback (most recent call last):
  File "/Users/snormore/Workspace/triage/keras-trainer/.venv/lib/python3.6/site-packages/keras/utils/data_utils.py", line 578, in get
    inputs = self.queue.get(block=True).get()
  File "/usr/local/Cellar/python/3.6.4_3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/multiprocessing/pool.py", line 644, in get
    raise self._value
  File "/usr/local/Cellar/python/3.6.4_3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/multiprocessing/pool.py", line 119, in worker
    result = (True, func(*args, **kwds))
  File "/Users/snormore/Workspace/triage/keras-trainer/.venv/lib/python3.6/site-packages/keras/utils/data_utils.py", line 401, in get_index
    return _SHARED_SEQUENCES[uid][i]
  File "/Users/snormore/Workspace/triage/keras-trainer/.venv/lib/python3.6/site-packages/keras/preprocessing/image.py", line 825, in __getitem__
    return self._get_batches_of_transformed_samples(index_array)
  File "/Users/snormore/Workspace/triage/keras-trainer/.venv/lib/python3.6/site-packages/keras/preprocessing/image.py", line 1233, in _get_batches_of_transformed_samples
    img = self.image_data_generator.preprocessing_function(img)
  File "/Users/snormore/Workspace/triage/keras-trainer/.venv/lib/python3.6/site-packages/keras_model_specs/model_spec.py", line 65, in <lambda>
    self.preprocess_input = lambda x: PREPROCESS_FUNCTIONS[self.preprocess_func](x, args=self.preprocess_args)
  File "/Users/snormore/Workspace/triage/keras-trainer/.venv/lib/python3.6/site-packages/keras_model_specs/model_spec.py", line 13, in between_plus_minus_1
    x /= 255.
TypeError: unsupported operand type(s) for /=: 'JpegImageFile' and 'float'

    1 #!/usr/bin/env python
The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.6.4_3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python/3.6.4_3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/snormore/Workspace/triage/keras-trainer/keras_trainer/run.py", line 30, in <module>
    trainer.run()
  File "/Users/snormore/Workspace/triage/keras-trainer/keras_trainer/trainer.py", line 267, in run
    max_queue_size=self.max_queue_size
  File "/Users/snormore/Workspace/triage/keras-trainer/.venv/lib/python3.6/site-packages/keras/legacy/interfaces.py", line 91, in wrapper
    return func(*args, **kwargs)
  File "/Users/snormore/Workspace/triage/keras-trainer/.venv/lib/python3.6/site-packages/keras/engine/training.py", line 2192, in fit_generator
    generator_output = next(output_generator)
  File "/Users/snormore/Workspace/triage/keras-trainer/.venv/lib/python3.6/site-packages/keras/utils/data_utils.py", line 584, in get
    six.raise_from(StopIteration(e), e)
  File "<string>", line 3, in raise_from
StopIteration: unsupported operand type(s) for /=: 'JpegImageFile' and 'float'
```

@jsalbert can you dig into this and see if you can re-create the failure in a test and then possibly PR a fix for it?

This is currently causing 🔴 CI on a couple downstream repos.