### PR TITLE
fix warning + error

### DIFF
--- a/keras_model_specs/model_spec.py
+++ b/keras_model_specs/model_spec.py
@@ -10,18 +10,18 @@ from keras.preprocessing.image import load_img
 
 def between_plus_minus_1(x, args=None):
     # equivalent to keras.applications.mobilenet.preprocess_input
-    x /= 255.
-    x -= 0.5
-    x *= 2.
+    x = x / 255.
+    x = x - 0.5
+    x = x * 2.
     return x
 
 
 def mean_subtraction(x, args=None):
     # equivalent to keras.applications.imagenet_utils.preprocess_input (with channels_first)
     mean_r, mean_g, mean_b = args
-    x -= [mean_r, mean_g, mean_b]
-    x /= 255.
-    x *= 2.
+    x = x - [mean_r, mean_g, mean_b]
+    x = x / 255.
+    x = x * 2.
     return x
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='keras-model-specs',
-    version='0.0.22',
+    version='0.0.23',
     description='A helper package for managing Keras model base architectures with overrides for target size and preprocessing functions.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='keras-model-specs',
-    version='0.0.21',
+    version='0.0.22',
     description='A helper package for managing Keras model base architectures with overrides for target size and preprocessing functions.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',
@@ -13,7 +13,7 @@ setup(
     packages=find_packages(exclude=['tests', '.cache', '.venv', '.git', 'dist']),
     include_package_data=True,
     install_requires=[
-        'Keras',
+        'Keras>=2.1.5',
         'h5py',
         'Pillow',
         'six'


### PR DESCRIPTION
Just wanted to try if this solves:
```WARNING:tensorflow:Variable *= will be deprecated. Use variable.assign_mul if you want assignment to the variable value or 'x = x * y' if you want a new python Tensor object.```