### PR TITLE
Freeze again at Keras 2.1.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     packages=find_packages(exclude=['tests', '.cache', '.venv', '.git', 'dist']),
     include_package_data=True,
     install_requires=[
-        'Keras>=2.1.5',
+        'Keras==2.1.4',
         'h5py',
         'Pillow',
         'six'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='keras-model-specs',
-    version='0.0.23',
+    version='0.0.24',
     description='A helper package for managing Keras model base architectures with overrides for target size and preprocessing functions.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',


### PR DESCRIPTION
In my last PR I updated the Keras minimum to 2.1.5, revert that change again to freeze it at 2.1.4 that is stable. 